### PR TITLE
Add formula arg to brew install

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Verify formula
         run: |
-          brew install --build-from-source Formula/resonate.rb && resonate -v
+          brew install --formula --build-from-source Formula/resonate.rb && resonate -v
 
       - name: Push changes
         uses: ad-m/github-push-action@v0.8.0


### PR DESCRIPTION
Suppresses unnecessary warning.

```
Error: Failed to load cask: Formula/resonate.rb
Cask 'resonate' is unreadable: wrong constant name #<Class:0x0000000129fb9300>

Warning: Treating Formula/resonate.rb as a formula.
```