### PR TITLE
chore: update resonate to v0.9.0

### DIFF
--- a/Formula/resonate.rb
+++ b/Formula/resonate.rb
@@ -1,23 +1,23 @@
 class Resonate < Formula
-  version '0.8.2'
+  version 'v0.9.0'
   desc "A dead simple programming model for the cloud"
   homepage "https://github.com/resonatehq/resonate"
   arch = Hardware::CPU.arch.to_s
   if OS.mac?
       if Hardware::CPU.arm?
           url "https://github.com/resonatehq/resonate/releases/download/v#{version}/resonate_darwin_aarch64.tar.gz"
-          sha256 "2e05108e4150da570ec61ffad9969f6fe70f2542411a0d0957f2fd4a1710e6d4"
+          sha256 "f38b9663c6f5933cf16e74d9488e13c5b5fad5478cfb30ee1aed9f2e24495e90"
       else
           url "https://github.com/resonatehq/resonate/releases/download/v#{version}/resonate_darwin_x86_64.tar.gz"
-          sha256 "9946d301aa579cbb699f999fdf7662ed747afd060d9409112d764af4e54fc5f3"
+          sha256 "b6d57b6cf40e8dc10ee1b873cf7ea49ef27e996aa455bec9ef08808e5714c9f3"
       end
   elsif OS.linux?
      if Hardware::CPU.arm?
          url "https://github.com/resonatehq/resonate/releases/download/v#{version}/resonate_linux_aarch64.tar.gz"
-         sha256 "a6a1e2392f3212ffd60775d45c0ec14d45e003d39f090e06ff75e1a46916fbd3"
+         sha256 "b091681b24202fd366ad81fbebc13f56a7adb067f29b6f429f0b3b3f09407dc3"
      else
          url "https://github.com/resonatehq/resonate/releases/download/v#{version}/resonate_linux_x86_64.tar.gz"
-         sha256 "38e77b7c9513b8e19e7f50fe9940d735afd462c36e664099161eb58746ca4eb2"
+         sha256 "a98fddccf664630ccd914e8e6c4bf0c8822d0836860c82a8175bb99de66a8947"
      end
   end
 


### PR DESCRIPTION
## Automated Formula Update

Updates Resonate formula to version **v0.9.0** from [release v0.9.0](https://github.com/resonatehq/resonate/releases/tag/v0.9.0).

### Changes
- Updated version to `v0.9.0`
- Updated sha256 checksums for all platforms (darwin/linux × x86_64/aarch64)

### Verification
- [ ] Checksums match published release artifacts
- [ ] Version matches Cargo.toml in resonate repository

---

🤖 Generated by [CD workflow](https://github.com/resonatehq/resonate/actions/workflows/cd.yml)