### PR TITLE
chore: update resonate to v0.9.0

### DIFF
--- a/Formula/resonate.rb
+++ b/Formula/resonate.rb
@@ -1,23 +1,23 @@
 class Resonate < Formula
-  version 'v0.9.0'
+  version '0.9.0'
   desc "A dead simple programming model for the cloud"
   homepage "https://github.com/resonatehq/resonate"
   arch = Hardware::CPU.arch.to_s
   if OS.mac?
       if Hardware::CPU.arm?
           url "https://github.com/resonatehq/resonate/releases/download/v#{version}/resonate_darwin_aarch64.tar.gz"
-          sha256 "166a70812eaefdb16de80c0c7449761ba17eabee40e51485c9f7159e585d33c0"
+          sha256 "a7f37ad8e5da6cdab86f18b1fd2f958ddc180f6db8d2de896cb042553f706922"
       else
           url "https://github.com/resonatehq/resonate/releases/download/v#{version}/resonate_darwin_x86_64.tar.gz"
-          sha256 "fcb90a12a1a8672af74bd2630841d1f1041817504101b5dad3499a284766b424"
+          sha256 "5fdaf14eb125012368da79d43696046a0d93327b69655e906c2c0fbb8100748f"
       end
   elsif OS.linux?
      if Hardware::CPU.arm?
          url "https://github.com/resonatehq/resonate/releases/download/v#{version}/resonate_linux_aarch64.tar.gz"
-         sha256 "e60d8f34ee2cbca961bb6f61c0fe97bcd64566c04e0c7a50051729778476298f"
+         sha256 "d59cddd5077f9d04484778fb4c5f2de2d50d42052c27bcb1da5da1d2eb25f043"
      else
          url "https://github.com/resonatehq/resonate/releases/download/v#{version}/resonate_linux_x86_64.tar.gz"
-         sha256 "c958a262a66fc13ec44584e8e88e1d4a9ebc779b629fe46fd95217aee98c6a57"
+         sha256 "27ca398bd922ea20329d3310d44e4c8cab1221674623f8d67b3527ff5ad68dfb"
      end
   end
 


### PR DESCRIPTION
## Automated Formula Update

Updates Resonate formula to version **v0.9.0** from [release v0.9.0](https://github.com/resonatehq/resonate/releases/tag/v0.9.0).

### Changes
- Updated version to `v0.9.0`
- Updated sha256 checksums for all platforms (darwin/linux × x86_64/aarch64)

### Verification
- [ ] Checksums match published release artifacts
- [ ] Version matches Cargo.toml in resonate repository

---

🤖 Generated by [CD workflow](https://github.com/resonatehq/resonate/actions/workflows/cd.yml)