### PR TITLE
chore: update resonate to v0.9.1

### DIFF
--- a/Formula/resonate.rb
+++ b/Formula/resonate.rb
@@ -1,23 +1,23 @@
 class Resonate < Formula
-  version '0.9.0'
+  version '0.9.1'
   desc "A dead simple programming model for the cloud"
   homepage "https://github.com/resonatehq/resonate"
   arch = Hardware::CPU.arch.to_s
   if OS.mac?
       if Hardware::CPU.arm?
           url "https://github.com/resonatehq/resonate/releases/download/v#{version}/resonate_darwin_aarch64.tar.gz"
-          sha256 "a7f37ad8e5da6cdab86f18b1fd2f958ddc180f6db8d2de896cb042553f706922"
+          sha256 "600fbdb5a693c676d4b1d6b6ea9a46c6ef692d56f9d962bf18a832721cc2bf1f"
       else
           url "https://github.com/resonatehq/resonate/releases/download/v#{version}/resonate_darwin_x86_64.tar.gz"
-          sha256 "5fdaf14eb125012368da79d43696046a0d93327b69655e906c2c0fbb8100748f"
+          sha256 "1e50a281e85b8a36d6c648e2aa32267c2da9890a94757b6280671efc9cd4397c"
       end
   elsif OS.linux?
      if Hardware::CPU.arm?
          url "https://github.com/resonatehq/resonate/releases/download/v#{version}/resonate_linux_aarch64.tar.gz"
-         sha256 "d59cddd5077f9d04484778fb4c5f2de2d50d42052c27bcb1da5da1d2eb25f043"
+         sha256 "2c8a328f42b20d0634906f1b3f8d0b0cc9bd17c838645cea7fc3bed9e6e89c6f"
      else
          url "https://github.com/resonatehq/resonate/releases/download/v#{version}/resonate_linux_x86_64.tar.gz"
-         sha256 "27ca398bd922ea20329d3310d44e4c8cab1221674623f8d67b3527ff5ad68dfb"
+         sha256 "4eb0defd4eeeaf211075e073cff37f0269863c68d11cc2cada55ee62b048abb1"
      end
   end
 


### PR DESCRIPTION
## Automated Formula Update

Updates Resonate formula to version **v0.9.1** from [release v0.9.1](https://github.com/resonatehq/resonate/releases/tag/v0.9.1).

### Changes
- Updated version to `v0.9.1`
- Updated sha256 checksums for all platforms (darwin/linux × x86_64/aarch64)

### Verification
- [ ] Checksums match published release artifacts
- [ ] Version matches Cargo.toml in resonate repository

---

🤖 Generated by [CD workflow](https://github.com/resonatehq/resonate/actions/workflows/cd.yml)