### PR TITLE
chore: update resonate to v0.9.2

### DIFF
--- a/Formula/resonate.rb
+++ b/Formula/resonate.rb
@@ -1,23 +1,23 @@
 class Resonate < Formula
-  version '0.9.1'
+  version '0.9.2'
   desc "A dead simple programming model for the cloud"
   homepage "https://github.com/resonatehq/resonate"
   arch = Hardware::CPU.arch.to_s
   if OS.mac?
       if Hardware::CPU.arm?
           url "https://github.com/resonatehq/resonate/releases/download/v#{version}/resonate_darwin_aarch64.tar.gz"
-          sha256 "600fbdb5a693c676d4b1d6b6ea9a46c6ef692d56f9d962bf18a832721cc2bf1f"
+          sha256 "b9ac1d904d0f82919abbfd78e7470b140ddfa5db087b65b298f1e70f405692fc"
       else
           url "https://github.com/resonatehq/resonate/releases/download/v#{version}/resonate_darwin_x86_64.tar.gz"
-          sha256 "1e50a281e85b8a36d6c648e2aa32267c2da9890a94757b6280671efc9cd4397c"
+          sha256 "f83f78b2efec48671eb4fa9733da48aea8ae41d939ffe752ecc6f3f7b315ce1c"
       end
   elsif OS.linux?
      if Hardware::CPU.arm?
          url "https://github.com/resonatehq/resonate/releases/download/v#{version}/resonate_linux_aarch64.tar.gz"
-         sha256 "2c8a328f42b20d0634906f1b3f8d0b0cc9bd17c838645cea7fc3bed9e6e89c6f"
+         sha256 "0fbc07233c1d7f366cc14331044d279cb3718cbc364f0a7d3b4f2132c6cb38ef"
      else
          url "https://github.com/resonatehq/resonate/releases/download/v#{version}/resonate_linux_x86_64.tar.gz"
-         sha256 "4eb0defd4eeeaf211075e073cff37f0269863c68d11cc2cada55ee62b048abb1"
+         sha256 "28df81b444cd51313b574ebdfa96a9ebfb8331ace7af38599ace72ad4c1a16c1"
      end
   end
 


### PR DESCRIPTION
## Automated Formula Update

Updates Resonate formula to version **v0.9.2** from [release v0.9.2](https://github.com/resonatehq/resonate/releases/tag/v0.9.2).

### Changes
- Updated version to `v0.9.2`
- Updated sha256 checksums for all platforms (darwin/linux × x86_64/aarch64)

### Verification
- [ ] Checksums match published release artifacts
- [ ] Version matches Cargo.toml in resonate repository

---

🤖 Generated by [CD workflow](https://github.com/resonatehq/resonate/actions/workflows/cd.yml)