### PR TITLE
chore: update resonate to v0.9.3

### DIFF
--- a/Formula/resonate.rb
+++ b/Formula/resonate.rb
@@ -1,23 +1,23 @@
 class Resonate < Formula
-  version '0.9.2'
+  version '0.9.3'
   desc "A dead simple programming model for the cloud"
   homepage "https://github.com/resonatehq/resonate"
   arch = Hardware::CPU.arch.to_s
   if OS.mac?
       if Hardware::CPU.arm?
           url "https://github.com/resonatehq/resonate/releases/download/v#{version}/resonate_darwin_aarch64.tar.gz"
-          sha256 "b9ac1d904d0f82919abbfd78e7470b140ddfa5db087b65b298f1e70f405692fc"
+          sha256 "bf5caa49f283e807e6830c01960408758b2f1425534a69966c3630c882706ce0"
       else
           url "https://github.com/resonatehq/resonate/releases/download/v#{version}/resonate_darwin_x86_64.tar.gz"
-          sha256 "f83f78b2efec48671eb4fa9733da48aea8ae41d939ffe752ecc6f3f7b315ce1c"
+          sha256 "65d7d92aac6493b969d31e72c1d31d2d7280305cfda780ecb5d5fe7a85164898"
       end
   elsif OS.linux?
      if Hardware::CPU.arm?
          url "https://github.com/resonatehq/resonate/releases/download/v#{version}/resonate_linux_aarch64.tar.gz"
-         sha256 "0fbc07233c1d7f366cc14331044d279cb3718cbc364f0a7d3b4f2132c6cb38ef"
+         sha256 "a3b11ed5d5c4acf89f5845d3b5b63c5555b98b65c02463d3c88419e169eed40a"
      else
          url "https://github.com/resonatehq/resonate/releases/download/v#{version}/resonate_linux_x86_64.tar.gz"
-         sha256 "28df81b444cd51313b574ebdfa96a9ebfb8331ace7af38599ace72ad4c1a16c1"
+         sha256 "b59adcca111115fe04436adf3c9db53d16a8a5a42339835b30048e36edbb31f2"
      end
   end
 


### PR DESCRIPTION
## Automated Formula Update

Updates Resonate formula to version **v0.9.3** from [release v0.9.3](https://github.com/resonatehq/resonate/releases/tag/v0.9.3).

### Changes
- Updated version to `v0.9.3`
- Updated sha256 checksums for all platforms (darwin/linux × x86_64/aarch64)

### Verification
- [ ] Checksums match published release artifacts
- [ ] Version matches Cargo.toml in resonate repository

---

🤖 Generated by [CD workflow](https://github.com/resonatehq/resonate/actions/workflows/cd.yml)