### PR TITLE
chore: update resonate to v0.9.4

### DIFF
--- a/Formula/resonate.rb
+++ b/Formula/resonate.rb
@@ -1,23 +1,23 @@
 class Resonate < Formula
-  version '0.9.3'
+  version '0.9.4'
   desc "A dead simple programming model for the cloud"
   homepage "https://github.com/resonatehq/resonate"
   arch = Hardware::CPU.arch.to_s
   if OS.mac?
       if Hardware::CPU.arm?
           url "https://github.com/resonatehq/resonate/releases/download/v#{version}/resonate_darwin_aarch64.tar.gz"
-          sha256 "bf5caa49f283e807e6830c01960408758b2f1425534a69966c3630c882706ce0"
+          sha256 "076c4e79240303f388e77b29d5fd51d7de5690cb39507c942a5da7099460666d"
       else
           url "https://github.com/resonatehq/resonate/releases/download/v#{version}/resonate_darwin_x86_64.tar.gz"
-          sha256 "65d7d92aac6493b969d31e72c1d31d2d7280305cfda780ecb5d5fe7a85164898"
+          sha256 "e017281e072d0b2fec80f06aa439881644a878b155584873234ff5bc840d2a56"
       end
   elsif OS.linux?
      if Hardware::CPU.arm?
          url "https://github.com/resonatehq/resonate/releases/download/v#{version}/resonate_linux_aarch64.tar.gz"
-         sha256 "a3b11ed5d5c4acf89f5845d3b5b63c5555b98b65c02463d3c88419e169eed40a"
+         sha256 "deb811e7e3ec09904bf2d6a72adedf22722e0dadf1e37d324b59ebfef9102ef2"
      else
          url "https://github.com/resonatehq/resonate/releases/download/v#{version}/resonate_linux_x86_64.tar.gz"
-         sha256 "b59adcca111115fe04436adf3c9db53d16a8a5a42339835b30048e36edbb31f2"
+         sha256 "88f3a41c21181e3b3eeea168e927ca069960fe4dfcc7ce441410af27a0340722"
      end
   end
 


### PR DESCRIPTION
## Automated Formula Update

Updates Resonate formula to version **v0.9.4** from [release v0.9.4](https://github.com/resonatehq/resonate/releases/tag/v0.9.4).

### Changes
- Updated version to `v0.9.4`
- Updated sha256 checksums for all platforms (darwin/linux × x86_64/aarch64)

### Verification
- [x] Checksums match published release artifacts
- [x] Version matches Cargo.toml in resonate repository

---

🤖 Generated by [CD workflow](https://github.com/resonatehq/resonate/actions/workflows/cd.yml)