### PR TITLE
chore: update resonate to v0.9.5

### DIFF
--- a/Formula/resonate.rb
+++ b/Formula/resonate.rb
@@ -1,23 +1,23 @@
 class Resonate < Formula
-  version '0.9.4'
+  version '0.9.5'
   desc "A dead simple programming model for the cloud"
   homepage "https://github.com/resonatehq/resonate"
   arch = Hardware::CPU.arch.to_s
   if OS.mac?
       if Hardware::CPU.arm?
           url "https://github.com/resonatehq/resonate/releases/download/v#{version}/resonate_darwin_aarch64.tar.gz"
-          sha256 "076c4e79240303f388e77b29d5fd51d7de5690cb39507c942a5da7099460666d"
+          sha256 "1b573a8388e7e16fa88437f989667af317e94b1b70404ebc971bb49afe0b74ad"
       else
           url "https://github.com/resonatehq/resonate/releases/download/v#{version}/resonate_darwin_x86_64.tar.gz"
-          sha256 "e017281e072d0b2fec80f06aa439881644a878b155584873234ff5bc840d2a56"
+          sha256 "879f3409257b8c26a74237edf8d8c5cf7d9468246e7bce584438bf2921f31704"
       end
   elsif OS.linux?
      if Hardware::CPU.arm?
          url "https://github.com/resonatehq/resonate/releases/download/v#{version}/resonate_linux_aarch64.tar.gz"
-         sha256 "deb811e7e3ec09904bf2d6a72adedf22722e0dadf1e37d324b59ebfef9102ef2"
+         sha256 "257e3e6040157288894fc47381c0f5a3016d44ca20e6ded8f8b354b5fcc7add9"
      else
          url "https://github.com/resonatehq/resonate/releases/download/v#{version}/resonate_linux_x86_64.tar.gz"
-         sha256 "88f3a41c21181e3b3eeea168e927ca069960fe4dfcc7ce441410af27a0340722"
+         sha256 "7760ea0baa163324e348ed6c94cf867e4f67e6469d1b5982c000eed8040fc4e2"
      end
   end
 


### PR DESCRIPTION
## Automated Formula Update

Updates Resonate formula to version **v0.9.5** from [release v0.9.5](https://github.com/resonatehq/resonate/releases/tag/v0.9.5).

### Changes
- Updated version to `v0.9.5`
- Updated sha256 checksums for all platforms (darwin/linux × x86_64/aarch64)

### Verification
- [x] Checksums match published release artifacts
- [x] Version matches Cargo.toml in resonate repository

---

🤖 Generated by [CD workflow](https://github.com/resonatehq/resonate/actions/workflows/cd.yml)