### PR TITLE
chore: update resonate to v0.9.6

### DIFF
--- a/Formula/resonate.rb
+++ b/Formula/resonate.rb
@@ -1,23 +1,23 @@
 class Resonate < Formula
-  version '0.9.5'
+  version '0.9.6'
   desc "A dead simple programming model for the cloud"
   homepage "https://github.com/resonatehq/resonate"
   arch = Hardware::CPU.arch.to_s
   if OS.mac?
       if Hardware::CPU.arm?
           url "https://github.com/resonatehq/resonate/releases/download/v#{version}/resonate_darwin_aarch64.tar.gz"
-          sha256 "1b573a8388e7e16fa88437f989667af317e94b1b70404ebc971bb49afe0b74ad"
+          sha256 "c7d8c579a59e5b05e113c281eb790ae45ac3dd094993c62a5fbb414e05e93c90"
       else
           url "https://github.com/resonatehq/resonate/releases/download/v#{version}/resonate_darwin_x86_64.tar.gz"
-          sha256 "879f3409257b8c26a74237edf8d8c5cf7d9468246e7bce584438bf2921f31704"
+          sha256 "8b8206ccdb4c4ac42d5b25d822028b864791906b6823ec30eaefcc9d3f6acba6"
       end
   elsif OS.linux?
      if Hardware::CPU.arm?
          url "https://github.com/resonatehq/resonate/releases/download/v#{version}/resonate_linux_aarch64.tar.gz"
-         sha256 "257e3e6040157288894fc47381c0f5a3016d44ca20e6ded8f8b354b5fcc7add9"
+         sha256 "4c7e11364ebab6300462441dad734587616df814dbc1f59d364052d18a7ae6aa"
      else
          url "https://github.com/resonatehq/resonate/releases/download/v#{version}/resonate_linux_x86_64.tar.gz"
-         sha256 "7760ea0baa163324e348ed6c94cf867e4f67e6469d1b5982c000eed8040fc4e2"
+         sha256 "0c4aa1761fdd35255b5c5057db1e9091ea18a51d5a680156f7178db25d560088"
      end
   end
 


### PR DESCRIPTION
## Automated Formula Update

Updates Resonate formula to version **v0.9.6** from [release v0.9.6](https://github.com/resonatehq/resonate/releases/tag/v0.9.6).

### Changes
- Updated version to `v0.9.6`
- Updated sha256 checksums for all platforms (darwin/linux × x86_64/aarch64)

### Verification
- [ ] Checksums match published release artifacts
- [ ] Version matches Cargo.toml in resonate repository

---

🤖 Generated by [CD workflow](https://github.com/resonatehq/resonate/actions/workflows/cd.yml)