### PR TITLE
chore: update resonate to v0.9.8

### DIFF
--- a/Formula/resonate.rb
+++ b/Formula/resonate.rb
@@ -1,23 +1,23 @@
 class Resonate < Formula
-  version '0.9.7'
+  version '0.9.8'
   desc "A dead simple programming model for the cloud"
   homepage "https://github.com/resonatehq/resonate"
   arch = Hardware::CPU.arch.to_s
   if OS.mac?
       if Hardware::CPU.arm?
           url "https://github.com/resonatehq/resonate/releases/download/v#{version}/resonate_darwin_aarch64.tar.gz"
-          sha256 "bd314ecdc496025648dd84d6f520f647f0c76e7573e79dfe83e1a77ed70f490c"
+          sha256 "cf6bbf0870955aef10679684ec533e71d9c478e59f0068e3b1ba1222661d9177"
       else
           url "https://github.com/resonatehq/resonate/releases/download/v#{version}/resonate_darwin_x86_64.tar.gz"
-          sha256 "827e6856f9bbff612052794de1235c29a59a4384de6d2d44e13b99228ef9560b"
+          sha256 "1f9f671512edf3b7b9aaac62140d616c5e4419dda8d2931381df2832b0314bc6"
       end
   elsif OS.linux?
      if Hardware::CPU.arm?
          url "https://github.com/resonatehq/resonate/releases/download/v#{version}/resonate_linux_aarch64.tar.gz"
-         sha256 "62f349ad5a7065342e541bbb85a598653413300f5b811eacc0e9b0fc2331d6f3"
+         sha256 "f9a701a33af0371674e7b9cd6534f13f9bcd7b363ed6e65322c9952f65ea3bc4"
      else
          url "https://github.com/resonatehq/resonate/releases/download/v#{version}/resonate_linux_x86_64.tar.gz"
-         sha256 "f004581d865ca6da6bed0853eade9c8b1be64feaf79514463dffa454eb74f6c9"
+         sha256 "67caa5d5fe0ae7219e2436e8f2d232b7bcc49814649e6a1c29e6545f4c45bca3"
      end
   end
 


### PR DESCRIPTION
## Automated Formula Update

Updates Resonate formula to version **v0.9.8** from [release v0.9.8](https://github.com/resonatehq/resonate/releases/tag/v0.9.8).

### Changes
- Updated version to `v0.9.8`
- Updated sha256 checksums for all platforms (darwin/linux × x86_64/aarch64)

### Verification
- [ ] Checksums match published release artifacts
- [ ] Version matches Cargo.toml in resonate repository

---

🤖 Generated by [CD workflow](https://github.com/resonatehq/resonate/actions/workflows/cd.yml)